### PR TITLE
fix: don't use colon after a figure reference

### DIFF
--- a/en/docs/systems-programming/index.html
+++ b/en/docs/systems-programming/index.html
@@ -330,7 +330,7 @@ which Node automatically stores in an array called <span class="ix-entry" ix-key
 The name of the program used to run our code is stored <code>process.argv[0]</code> (which in this case is <code>node</code>),
 while <code>process.argv[1]</code> is the name of our program (in this case <code>list-dir-wrong.js</code>).
 The rest of <code>process.argv</code> holds whatever arguments we gave at the command line when we ran the program,
-so <code>process.argv[2]</code> is the first argument after the name of our program (<a class="fig-ref" href="../systems-programming/#systems-programming-process-argv">Figure 2.1</a>):</p>
+so <code>process.argv[2]</code> is the first argument after the name of our program (<a class="fig-ref" href="../systems-programming/#systems-programming-process-argv">Figure 2.1</a>).</p>
 <figure id="systems-programming-process-argv">
   <img src="./process-argv.svg" alt="Command-line arguments in <code>process.argv</code>"/>
   <figcaption markdown="1">Figure 2.1: How Node stores command-line arguments in <code>process.argv</code>.</figcaption>

--- a/en/src/systems-programming/index.md
+++ b/en/src/systems-programming/index.md
@@ -85,7 +85,7 @@ which Node automatically stores in an array called [%i "process.argv" %]`process
 The name of the program used to run our code is stored `process.argv[0]` (which in this case is `node`),
 while `process.argv[1]` is the name of our program (in this case `list-dir-wrong.js`).
 The rest of `process.argv` holds whatever arguments we gave at the command line when we ran the program,
-so `process.argv[2]` is the first argument after the name of our program ([%f systems-programming-process-argv %]):
+so `process.argv[2]` is the first argument after the name of our program ([%f systems-programming-process-argv %]).
 
 [% figure
    slug="systems-programming-process-argv"


### PR DESCRIPTION
This is subtle fix, but with not so subtle implications.
While using colon after a figure reference could look great in the HTML version:

![image](https://user-images.githubusercontent.com/1078305/191944054-dc3dc005-6ce6-4c43-9fd4-82af9073df0f.png)

It certainly looks like an error in the PDF version, where LaTeX decides the layout of the images inside the page:

![image](https://user-images.githubusercontent.com/1078305/191944226-9c72319c-1651-42f9-a650-9290a9d25590.png)
