### PR TITLE
Support older versions of pdfTeX

### DIFF
--- a/en/src/systems-programming/index.md
+++ b/en/src/systems-programming/index.md
@@ -475,7 +475,7 @@ that make code like this easier to read.
 
 ### Where is Node? {: .exercise}
 
-Write a program called `wherenode.js` that prints the full path to the version of Node is is run with.
+Write a program called `wherenode.js` that prints the full path to the version of Node it is run with.
 
 ### Tracing callbacks {: .exercise}
 

--- a/info/head.tex
+++ b/info/head.tex
@@ -162,6 +162,7 @@ backgroundcolor=black!5]{tBox}
 }
 
 % Unicode characters.
+\usepackage[utf8]{inputenc}
 \usepackage{newunicodechar}
 \newunicodechar{√}{$\sqrt{}$}
 


### PR DESCRIPTION
In one of my computers I'm using an oldish LaTeX distribution,

```
➜  en git:(main) ✗ pdflatex --version
pdfTeX 3.14159265-2.6-1.40.18 (TeX Live 2017)
```
that in turn is using an oldish version of the _newunicodechar_ package.
Using that version (or an older one from 2014, for example) we need to add this package
`\usepackage[utf8]{inputenc}`
before this one
`\usepackage{newunicodechar}`
in order to get correctly formatted UTF-8 characters.

Please, have a look at the results before applying this patch / commit:

<img width="664" alt="image" src="https://user-images.githubusercontent.com/1078305/192112260-710532cd-6613-4f53-be62-d9ba2b21c2db.png">

and after applying the patch:

<img width="687" alt="image" src="https://user-images.githubusercontent.com/1078305/192112289-30acc2f9-b5ed-4b07-9d22-8836a5a6e2d0.png">

As far as I can tell adding this new line to `info/head.tex` has not any unwanted effect in those computers running a modern version of LaTeX.