### PR TITLE
Fix "terms defined" template behavior 

### DIFF
--- a/en/src/systems-programming/index.md
+++ b/en/src/systems-programming/index.md
@@ -475,7 +475,7 @@ that make code like this easier to read.
 
 ### Where is Node? {: .exercise}
 
-Write a program called `wherenode.js` that prints the full path to the version of Node is is run with.
+Write a program called `wherenode.js` that prints the full path to the version of Node it is run with.
 
 ### Tracing callbacks {: .exercise}
 

--- a/info/head.tex
+++ b/info/head.tex
@@ -162,6 +162,7 @@ backgroundcolor=black!5]{tBox}
 }
 
 % Unicode characters.
+\usepackage[utf8]{inputenc}
 \usepackage{newunicodechar}
 \newunicodechar{√}{$\sqrt{}$}
 

--- a/lib/mccole/templates/definitions.html
+++ b/lib/mccole/templates/definitions.html
@@ -1,4 +1,4 @@
-{% for node_slug, terms in site.mccole.definitions %}{% if node_slug == node.slug %}
+{% for node_slug, terms in site.mccole.definitions %}{% if node_slug == node.slug and terms %}
 <p class="definitions">
   Terms defined: {% for gl_slug, term in terms %}<a class="gl-ref" href="@root/glossary/#{{gl_slug}}" markdown="1">{{term}}</a>{% if not loop.is_last %}, {% endif %}{% endfor %}
 </p>


### PR DESCRIPTION
This template 
https://github.com/gvwilson/sdxjs/blob/main/lib/mccole/templates/definitions.html
tries to add the _"Terms defined"_ header to each chapter. The problem is that the first chapter doesn't have any terms defined (but the template keeps adding the _"Terms defined"_ header)

Adding the `` and terms `` condition to the template seems to solve the problem

``{% if node_slug == node.slug and terms %}``

Before applying the patch it looked like this:

<img width="1297" alt="image" src="https://user-images.githubusercontent.com/1078305/192115388-7e015fd0-e5be-48fc-8d99-dc525c2934e2.png">

<img width="702" alt="image" src="https://user-images.githubusercontent.com/1078305/192115408-f9104ce0-6138-4245-9822-408089f7a498.png">


