### PR TITLE
Fix typos

### DIFF
--- a/en/docs/async-programming/index.html
+++ b/en/docs/async-programming/index.html
@@ -695,8 +695,8 @@ second then: resolving: inner delay
     if we want to use a library function that relies on callbacks,
     we have to convert it to use promises.
     Doing this is called <a class="gl-ref" href="../glossary/#promisification" markdown="1">promisification</a>
-    (because programmers will rarely pass up an opportunity add a bit of jargon to the world),
-    and most functions in the Node have already been promisified.</p>
+    (because programmers will rarely pass up an opportunity to add a bit of jargon to the world),
+    and most functions in Node have already been promisified.</p>
 </li>
 </ol>
 <h2 id="async-programming-tools">Section 3.5: How can we build tools with promises?</h2>

--- a/en/src/async-programming/index.md
+++ b/en/src/async-programming/index.md
@@ -293,8 +293,8 @@ We therefore have three rules for chaining promises:
     if we want to use a library function that relies on callbacks,
     we have to convert it to use promises.
     Doing this is called [%g promisification "promisification" %]
-    (because programmers will rarely pass up an opportunity add a bit of jargon to the world),
-    and most functions in the Node have already been promisified.
+    (because programmers will rarely pass up an opportunity to add a bit of jargon to the world),
+    and most functions in Node have already been promisified.
 
 ## How can we build tools with promises? {: #async-programming-tools}
 


### PR DESCRIPTION
I'm not sure if here: _"and most functions in **the** Node have already been promisified"_ you wanted to say
_" and most functions in Node have already been promisified."_  or _" and most functions in the Node ecosystem have already been promisified."_ (or something similar). For this patch I chose the former. 