### PR TITLE
Add a couple of Emacs backup files so the next code example makes sense

### DIFF
--- a/en/docs/systems-programming/glob-all-files.slice.out
+++ b/en/docs/systems-programming/glob-all-files.slice.out
@@ -1,7 +1,9 @@
 copy-file-filtered.js
+copy-file-filtered.js~
 copy-file-unfiltered.js
 copy-file-unfiltered.out
 copy-file-unfiltered.sh
+copy-file-unfiltered.sh~
 copy-file-unfiltered.txt
 ...
 x-trace-anonymous.md

--- a/en/src/systems-programming/glob-all-files.slice.out
+++ b/en/src/systems-programming/glob-all-files.slice.out
@@ -1,7 +1,9 @@
 copy-file-filtered.js
+copy-file-filtered.js~
 copy-file-unfiltered.js
 copy-file-unfiltered.out
 copy-file-unfiltered.sh
+copy-file-unfiltered.sh~
 copy-file-unfiltered.txt
 ...
 x-trace-anonymous.md


### PR DESCRIPTION
The code snippet  in `en/docs/systems-programming/glob-get-then-filter-pedantic.js` is trying to show how to use _filter_ to remove unwanted Emacs backup files from the output. However, those ~ files are not shown in the previous snippet's (`glob-all-files.js`) output.