### PR TITLE
Disable TeX ligatures (show double dashes correctly)

### DIFF
--- a/info/head.tex
+++ b/info/head.tex
@@ -6,6 +6,10 @@
 % Font encoding.
 \usepackage[T1]{fontenc}
 
+% Disable ligatures. https://tex.stackexchange.com/a/36702
+\usepackage{microtype}
+\DisableLigatures{}
+
 % Bibliography.
 \usepackage[backend=biber,style=alphabetic,sorting=nyt,maxbibnames=99]{biblatex}
 \addbibresource{bibliography.bib}


### PR DESCRIPTION
When using the `fontenc` package, LaTeX automatically converts two hyphens to a single hyphen. This behavior is specially frustrating when the PDF explicitly refers to how to use double dashes to handle command line parameters:

<img width="705" alt="image" src="https://user-images.githubusercontent.com/1078305/192743289-e8890cfc-392b-4b0f-8fea-8025e9808e29.png">

<img width="704" alt="image" src="https://user-images.githubusercontent.com/1078305/192743758-ce575c7e-ca40-4cb1-a21c-d616ecd67793.png">

This patch aims to fix that behavior:

<img width="622" alt="image" src="https://user-images.githubusercontent.com/1078305/192743908-02feaa6a-0575-4e18-b14d-43d39fdceb3c.png">

<img width="639" alt="image" src="https://user-images.githubusercontent.com/1078305/192743995-fbd26806-1e23-4892-80e8-11103b28821e.png">


See: https://tex.stackexchange.com/questions/36692/how-do-i-prevent-latex-from-creating-en-dash-and-em-dash/36702