### PR TITLE
Fix mocha: command not found output bug

### DIFF
--- a/en/docs/file-backup/index.html
+++ b/en/docs/file-backup/index.html
@@ -718,7 +718,16 @@ Mocha looks for files in <code>test</code> sub-directories of the directories ho
 <div class="highlight"><pre><span></span><code>&gt; stjs@1.0.0 test
 &gt; mocha */test/test-*.js &quot;-g&quot; &quot;pre-existing hashes&quot;
 
-sh: mocha: command not found
+
+  pre-existing hashes and actual filesystem
+    ✓ finds no pre-existing files when none given or exist
+    ✓ finds some files when one is given and none exist
+    ✓ finds nothing needs backup when there is a match
+    ✓ finds something needs backup when there is a mismatch
+    ✓ finds mixed matches
+
+
+  5 passing (16ms)
 </code></pre></div>
 </div>
 <h2 id="file-backup-test">Section 5.4: How can we test code that modifies files?</h2>

--- a/en/docs/file-backup/test-check-filesystem.out
+++ b/en/docs/file-backup/test-check-filesystem.out
@@ -2,4 +2,13 @@
 > stjs@1.0.0 test
 > mocha */test/test-*.js "-g" "pre-existing hashes"
 
-sh: mocha: command not found
+
+  pre-existing hashes and actual filesystem
+    ✓ finds no pre-existing files when none given or exist
+    ✓ finds some files when one is given and none exist
+    ✓ finds nothing needs backup when there is a match
+    ✓ finds something needs backup when there is a mismatch
+    ✓ finds mixed matches
+
+
+  5 passing (16ms)

--- a/en/src/file-backup/test-check-filesystem.out
+++ b/en/src/file-backup/test-check-filesystem.out
@@ -2,4 +2,13 @@
 > stjs@1.0.0 test
 > mocha */test/test-*.js "-g" "pre-existing hashes"
 
-sh: mocha: command not found
+
+  pre-existing hashes and actual filesystem
+    ✓ finds no pre-existing files when none given or exist
+    ✓ finds some files when one is given and none exist
+    ✓ finds nothing needs backup when there is a match
+    ✓ finds something needs backup when there is a mismatch
+    ✓ finds mixed matches
+
+
+  5 passing (16ms)

--- a/info/head.tex
+++ b/info/head.tex
@@ -169,6 +169,7 @@ backgroundcolor=black!5]{tBox}
 \usepackage[utf8]{inputenc}
 \usepackage{newunicodechar}
 \newunicodechar{√}{$\sqrt{}$}
+\newunicodechar{✓}{\checkmark}
 
 % Don't indent footnotes.
 \usepackage[hang,flushmargin,bottom]{footmisc}


### PR DESCRIPTION
This patch adds correct output after executing mocha to test `check-existing-files.js` _findNew_ method.

Before applying the patch the output was looking weird:

<img width="654" alt="image" src="https://user-images.githubusercontent.com/1078305/193275634-1fa90eb1-2488-4369-968f-a6791484948f.png">

After applying it, the PDF (and the HTML) version looks OK:

<img width="633" alt="image" src="https://user-images.githubusercontent.com/1078305/193276281-f76eeee2-7590-4b79-b554-d3ad98b79976.png">

To reproduce mocha's output as closely as possible, this patch also needs to introduce a new unicode character to be parsed by LaTeX: 

`\newunicodechar{✓}{\checkmark}`