### PR TITLE
Fix typos. Add node to the index

### DIFF
--- a/en/docs/contents/index.html
+++ b/en/docs/contents/index.html
@@ -508,6 +508,7 @@
 <li>namespace: <a class="ix-ref" ix-ref="namespace" href="../module-loader/">Module Loader</a></li>
 <li>nested function: <a class="ix-ref" ix-ref="nested function" href="../code-generator/">Code Generator</a></li>
 <li>Nison, Maël: <a class="ix-ref" ix-ref="Nison, Maël" href="../package-manager/">Package Manager</a></li>
+<li>node: <a class="ix-ref" ix-ref="node" href="../pattern-matching/">Pattern Matching</a></li>
 <li>non-blocking execution: <a class="ix-ref" ix-ref="non-blocking execution" href="../async-programming/">Asynchronous Programming</a></li>
 <li>Nystrom, Bob: <a class="ix-ref" ix-ref="Nystrom, Bob" href="../virtual-machine/">Virtual Machine</a></li>
 <li>op code: <a class="ix-ref" ix-ref="op code" href="../virtual-machine/">Virtual Machine</a></li>

--- a/en/docs/data-table/index.html
+++ b/en/docs/data-table/index.html
@@ -936,7 +936,7 @@ they limit the length of the strings in a column to some fixed size
 and <a class="gl-ref" href="../glossary/#pad_string" markdown="1">pad</a> strings that are shorter than that.</p>
 <ol>
 <li>
-<p>Write a function that takes an array of strings and an integer with
+<p>Write a function that takes an array of strings and an integer width
     and creates an <code>ArrayBuffer</code> containing the strings padded to that width.
     The function should throw an exception if any of the strings
     are longer than the specified width.</p>

--- a/en/docs/pattern-matching/index.html
+++ b/en/docs/pattern-matching/index.html
@@ -232,7 +232,7 @@ so we will start by looking at them.</p>
 <p>Programs stores HTML pages in memory using a <span class="ix-entry" ix-key="DOM;Document Object Model" markdown="1"><a class="gl-ref" href="../glossary/#dom" markdown="1">document object model</a></span> or DOM.
 Each element in the page,
 such as a heading and or paragraph,
-is a <a class="gl-ref" href="../glossary/#node" markdown="1">nodes</a>;
+is a <span class="ix-entry" ix-key="node" markdown="1"><a class="gl-ref" href="../glossary/#node" markdown="1">node</a></span>;
 the <a class="gl-ref" href="../glossary/#child_tree" markdown="1">children</a> of a node are the elements it contains
 (<a class="fig-ref" href="../pattern-matching/#pattern-matching-dom-tree">Figure 7.1</a>).</p>
 <figure id="pattern-matching-dom-tree">

--- a/en/src/data-table/index.md
+++ b/en/src/data-table/index.md
@@ -453,7 +453,7 @@ i.e.,
 they limit the length of the strings in a column to some fixed size
 and [%g pad_string "pad" %] strings that are shorter than that.
 
-1.  Write a function that takes an array of strings and an integer with
+1.  Write a function that takes an array of strings and an integer width
     and creates an `ArrayBuffer` containing the strings padded to that width.
     The function should throw an exception if any of the strings
     are longer than the specified width.

--- a/en/src/pattern-matching/index.md
+++ b/en/src/pattern-matching/index.md
@@ -19,7 +19,7 @@ so we will start by looking at them.
 Programs stores HTML pages in memory using a [%i "DOM" "Document Object Model" %][%g dom "document object model" %][%/i%] or DOM.
 Each element in the page,
 such as a heading and or paragraph,
-is a [%g node "nodes" %];
+is a [%i "node" %][%g node "node" %][%/i%];
 the [%g child_tree "children" %] of a node are the elements it contains
 ([%f pattern-matching-dom-tree %]).
 


### PR DESCRIPTION
The `node` term is defined in the glossary so I think that it also deserves to be added to the index