### PR TITLE
Fix array index so the example makes sense

### DIFF
--- a/en/docs/page-templates/index.html
+++ b/en/docs/page-templates/index.html
@@ -995,12 +995,12 @@ will almost certainly be different from the software that
 an expert can understand most quickly.
 In an ideal world our tools would automatically re-represent programs at different levels,
 so that with a click of a button we could view our code as either:</p>
-<div class="highlight"><pre><span></span><code>const hosts = links.map(a =&gt; a.href.split(&#39;:&#39;)[1].split(&#39;/&#39;)[0]).unique()
+<div class="highlight"><pre><span></span><code>const hosts = links.map(a =&gt; a.href.split(&#39;:&#39;)[1].split(&#39;/&#39;)[2]).unique()
 </code></pre></div>
 <p>or:</p>
 <div class="highlight"><pre><span></span><code>hosts = []
 for (each a in links) do
-  temp &lt;- attr(a, &#39;href&#39;).split(&#39;:&#39;)[1].split(&#39;/&#39;)[0]
+  temp &lt;- attr(a, &#39;href&#39;).split(&#39;:&#39;)[1].split(&#39;/&#39;)[2]
   if (not (temp in hosts)) do
     hosts.append(temp)
   end

--- a/en/src/page-templates/index.md
+++ b/en/src/page-templates/index.md
@@ -485,7 +485,7 @@ In an ideal world our tools would automatically re-represent programs at differe
 so that with a click of a button we could view our code as either:
 
 ```
-const hosts = links.map(a => a.href.split(':')[1].split('/')[0]).unique()
+const hosts = links.map(a => a.href.split(':')[1].split('/')[2]).unique()
 ```
 
 or:
@@ -493,7 +493,7 @@ or:
 ```
 hosts = []
 for (each a in links) do
-  temp <- attr(a, 'href').split(':')[1].split('/')[0]
+  temp <- attr(a, 'href').split(':')[1].split('/')[2]
   if (not (temp in hosts)) do
     hosts.append(temp)
   end


### PR DESCRIPTION
For this example:
```
const hosts = links.map(a => a.href.split(':')[1].split('/')[0]).unique()
```

I think that the number to index the array generated by the second split should be `2` instead of `0`.

A small proof of my point follows.
Here, using index `0` after the split, will yield an empty result:
```
let links = ['https://ikasten.io/cc/c.html', 'https://ehu.eus/bb/b.html', 'https://ikasten.io/aa/as.html']
const hosts = links.map(a=> console.log( a.split(':')[1].split('/')[0] ) )
```

While using `2` will yield the hostnames (on which we could apply the unique() function)
```
let links = ['https://ikasten.io/cc/c.html', 'https://ehu.eus/bb/b.html', 'https://ikasten.io/aa/as.html']
const hosts = links.map(a=> console.log( a.split(':')[1].split('/')[2] ) )
ikasten.io
ehu.eus
ikasten.io
```