### PR TITLE
fixed-width sidebar

### DIFF
--- a/lib/mccole/resources/mccole.css
+++ b/lib/mccole/resources/mccole.css
@@ -27,6 +27,8 @@
     --stamp-blue: #1B2A83;
     --stamp-green: #7F9971;
     --stamp-orange: #AD7353;
+
+    --sidebar-width: 300px;
 }
 
 /*
@@ -64,6 +66,11 @@ body {
     font-family: "Lucida Grande", Arial, sans-serif;
 }
 
+/* don't change header line-height */
+h1, h2, h3 {
+  line-height: normal;
+}
+
 /*
  * Code sections.
  */
@@ -76,17 +83,29 @@ code {
  * Two-column display with nav bar on the left.
  */
 
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: var(--sidebar-width);
+  padding: 1rem;
+  box-sizing: border-box;
+  overflow-y: auto;
+  background-color: var(--faintgray);
+}
+
+.logo {
+  width: 30px;
+}
+
 div.bordered {
     border-left: solid var(--mediumborder) var(--lightgray);
 }
 
-div.row {
-    display: grid;
-    grid-template-columns: 25% 75%;
-}
-
-div.column {
-    padding: 1rem;
+div.contents {
+  margin-left: var(--sidebar-width);
+  padding: 1rem;
 }
 
 /*

--- a/lib/mccole/templates/contents.html
+++ b/lib/mccole/templates/contents.html
@@ -1,5 +1,5 @@
 <p>
-  <img src="@root/logo.svg" alt="site logo" style="width: 10%" />
+  <img src="@root/logo.svg" alt="site logo" class="logo" />
   <a href="@root/">{{ site.title }}</a>
 </p>
 <ol class="toc-chapter">

--- a/lib/mccole/templates/node.ibis
+++ b/lib/mccole/templates/node.ibis
@@ -3,14 +3,14 @@
   {% include "head.html" %}
   <body>
     <div class="row">
-      <div class="column">
+      <div class="sidebar">
         {% include "contents.html" %}
       </div>
-      <div id="printable" class="column bordered{% if node.slug in site.todo %} todo{% endif %}">
+      <div id="printable" class="contents bordered{% if node.slug in site.todo %} todo{% endif %}">
         <main>
-	  {% include "title.html" %}
+          {% include "title.html" %}
           {% include "syllabus.html" %}
-	  {% include "definitions.html" %}
+          {% include "definitions.html" %}
           {{ node.html }}
         </main>
       </div>


### PR DESCRIPTION
Issue: https://github.com/gvwilson/sdxjs/issues/32

The existing sidebar doesn't play nicely with small screens, per the tweeted issue.

This PR makes the sidebar a fixed width, which trades consistency (yay!) for some issues if there were ever a chapter title that exceeded the fixed width.

Sidebar also now floats down the page with you as you read the chapter (position: fixed) and has a separate scroll context from the main page, if there's vertical overflow.

Setting the background color makes it so that, when content overflows the x direction in the main contents of the page, scrolling left and right won't result in text competes for space with the sidebar; instead it scrolls 'underneath' the sidebar.

Other drive-by nit-fixes:
- line heights for headings
- fixed logo size in the sidebar
- whitespace in the node.ibis template

At narrow screen width:

<img width="497" alt="749E39EB-BAED-47FD-BEAB-815A9A37E206-576-000756E268671C5F" src="https://user-images.githubusercontent.com/3818920/199625907-3a1ffd77-214f-46a6-b50e-df332db5d868.png">

Question: I didn't commit the updated build artifacts (docs/), but can push those changes too if that's appropriate. It's a little unclear to me whether those should be updated or not as part of this kind of change.