### PR TITLE
Toggleable Sidebar

### DIFF
--- a/lib/mccole/resources/mccole.css
+++ b/lib/mccole/resources/mccole.css
@@ -20,6 +20,7 @@
 
     --extra-vertical-space: 1ex;
     --slide-padding: 2em;
+    --sidebar-width: 300px;
 
     --stamp-brown: #5F483C;
     --stamp-red: #8B000F;
@@ -27,8 +28,6 @@
     --stamp-blue: #1B2A83;
     --stamp-green: #7F9971;
     --stamp-orange: #AD7353;
-
-    --sidebar-width: 300px;
 }
 
 /*
@@ -80,7 +79,7 @@ code {
 }
 
 /*
- * Two-column display with nav bar on the left.
+ * Toggle-able nav bar on the left.
  */
 
 .sidebar {
@@ -93,19 +92,32 @@ code {
   box-sizing: border-box;
   overflow-y: auto;
   background-color: var(--faintgray);
+  transition: transform 0.2s;
+}
+
+.sidebar-hidden .sidebar {
+  transform: translateX(calc(0px - var(--sidebar-width)));
+}
+
+div.contents {
+  transition: transform 0.2s;
+  padding: 1rem;
+}
+
+.sidebar-visible .contents {
+  transform: translateX(var(--sidebar-width));
+}
+
+.sidebar-hidden .contents {
+  transform: none; 
+}
+
+button.sidebar-toggle {
+  padding: 2px 8px;
 }
 
 .logo {
   width: 30px;
-}
-
-div.bordered {
-    border-left: solid var(--mediumborder) var(--lightgray);
-}
-
-div.contents {
-  margin-left: var(--sidebar-width);
-  padding: 1rem;
 }
 
 /*

--- a/lib/mccole/resources/mccole.css
+++ b/lib/mccole/resources/mccole.css
@@ -27,6 +27,8 @@
     --stamp-blue: #1B2A83;
     --stamp-green: #7F9971;
     --stamp-orange: #AD7353;
+
+    --sidebar-width: 300px;
 }
 
 /*
@@ -64,6 +66,11 @@ body {
     font-family: "Lucida Grande", Arial, sans-serif;
 }
 
+/* don't change header line-height */
+h1, h2, h3 {
+  line-height: normal;
+}
+
 /*
  * Code sections.
  */
@@ -76,17 +83,29 @@ code {
  * Two-column display with nav bar on the left.
  */
 
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: var(--sidebar-width);
+  padding: 1rem;
+  box-sizing: border-box;
+  overflow-y: auto;
+  background-color: var(--faintgray);
+}
+
+.logo {
+  width: 30px;
+}
+
 div.bordered {
     border-left: solid var(--mediumborder) var(--lightgray);
 }
 
-div.row {
-    display: grid;
-    grid-template-columns: 25% 75%;
-}
-
-div.column {
-    padding: 1rem;
+div.contents {
+  margin-left: var(--sidebar-width);
+  padding: 1rem;
 }
 
 /*

--- a/lib/mccole/templates/contents.html
+++ b/lib/mccole/templates/contents.html
@@ -1,5 +1,5 @@
 <p>
-  <img src="@root/logo.svg" alt="site logo" style="width: 10%" />
+  <img src="@root/logo.svg" alt="site logo" class="logo" />
   <a href="@root/">{{ site.title }}</a>
 </p>
 <ol class="toc-chapter">

--- a/lib/mccole/templates/contents.html
+++ b/lib/mccole/templates/contents.html
@@ -1,22 +1,35 @@
-<p>
+<!-- Hide / unhide sidebar before it is displayed -->
+<script type="text/javascript">
+  var html = document.querySelector('html');
+  var sidebar = 'hidden';
+  if (document.body.clientWidth >= 1080) {
+    sidebar = 'visible';
+  }
+  html.classList.add("sidebar-" + sidebar);
+</script>
+
+
+<div class="sidebar">
+  <p>
   <img src="@root/logo.svg" alt="site logo" class="logo" />
   <a href="@root/">{{ site.title }}</a>
-</p>
-<ol class="toc-chapter">
-  {% for slug, title in site.mccole.titles.chapters %}
-  <li{% if slug in site.todo %} class="todo"{% endif %}>
-    <a href="@root/{{ slug }}/">
-      {% if slug == node.slug %}<strong>{% endif %}{{ title }}{% if slug == node.slug %}</strong>{% endif %}
-    </a>
-  </li>
-  {% endfor %}
-</ol>
-<ol class="toc-appendix">
-  {% for slug, title in site.mccole.titles.appendices %}
-  <li{% if slug in site.todo %} class="todo"{% endif %}>
-    <a href="@root/{{ slug }}/">
-      {% if slug == node.slug %}<strong>{% endif %}{{ title }}{% if slug == node.slug %}</strong>{% endif %}
-    </a>
-  </li>
-  {% endfor %}
-</ol>
+  </p>
+  <ol class="toc-chapter">
+    {% for slug, title in site.mccole.titles.chapters %}
+    <li{% if slug in site.todo %} class="todo"{% endif %}>
+      <a href="@root/{{ slug }}/">
+        {% if slug == node.slug %}<strong>{% endif %}{{ title }}{% if slug == node.slug %}</strong>{% endif %}
+      </a>
+    </li>
+    {% endfor %}
+  </ol>
+  <ol class="toc-appendix">
+    {% for slug, title in site.mccole.titles.appendices %}
+    <li{% if slug in site.todo %} class="todo"{% endif %}>
+      <a href="@root/{{ slug }}/">
+        {% if slug == node.slug %}<strong>{% endif %}{{ title }}{% if slug == node.slug %}</strong>{% endif %}
+      </a>
+    </li>
+    {% endfor %}
+  </ol>
+</div>

--- a/lib/mccole/templates/node.ibis
+++ b/lib/mccole/templates/node.ibis
@@ -3,14 +3,14 @@
   {% include "head.html" %}
   <body>
     <div class="row">
-      <div class="column">
+      <div class="sidebar">
         {% include "contents.html" %}
       </div>
-      <div id="printable" class="column bordered{% if node.slug in site.todo %} todo{% endif %}">
+      <div id="printable" class="contents bordered{% if node.slug in site.todo %} todo{% endif %}">
         <main>
-	  {% include "title.html" %}
+          {% include "title.html" %}
           {% include "syllabus.html" %}
-	  {% include "definitions.html" %}
+          {% include "definitions.html" %}
           {{ node.html }}
         </main>
       </div>

--- a/lib/mccole/templates/node.ibis
+++ b/lib/mccole/templates/node.ibis
@@ -3,11 +3,10 @@
   {% include "head.html" %}
   <body>
     <div class="row">
-      <div class="sidebar">
-        {% include "contents.html" %}
-      </div>
-      <div id="printable" class="contents bordered{% if node.slug in site.todo %} todo{% endif %}">
+      {% include "contents.html" %}
+      <div id="printable" class="contents {% if node.slug in site.todo %} todo{% endif %}">
         <main>
+          <button class="sidebar-toggle">☰</button>
           {% include "title.html" %}
           {% include "syllabus.html" %}
           {% include "definitions.html" %}
@@ -15,5 +14,16 @@
         </main>
       </div>
     </div>
+    <!-- Hide / unhide sidebar on clicking the toggle -->
+    <script type="text/javascript">
+      document
+        .querySelector('.sidebar-toggle')
+        .addEventListener('click', function toggleSidebar() {
+          var html = document.querySelector('html');
+          html.classList.toggle('sidebar-hidden');
+          html.classList.toggle('sidebar-visible');
+        });
+    </script>
+
   </body>
 </html>


### PR DESCRIPTION
Issue: https://github.com/gvwilson/sdxjs/issues/32
Ref: https://github.com/gvwilson/sdxjs/pull/33

Adds a button to hide / show the sidebar.

* Button is unobtrusive, it's just ☰ (U+2630)with a little padding
* For screens < 1080px, sidebar defaults to closed
* The js is a little inline script tag, should be easy to find / modify if anyone has a bright idea
* The CSS is a little cute; it uses a negative transform to move the sidebar away so that it can have a transition. 


This PR is stacked on top of the fixed-width sidebar PR. [Compare just the diff that adds the JS](https://github.com/rrcobb/sdxjs/compare/sidebar-css...rrcobb:sdxjs:sidebar-js?expand=1)