### PR TITLE
ivy project has been renamed to ark

### DIFF
--- a/lib/mccole/extensions/acknowledgments.py
+++ b/lib/mccole/extensions/acknowledgments.py
@@ -1,6 +1,6 @@
 """Generate list of acknowledgments."""
 
-import ivy
+import ark
 import shortcodes
 import util
 import yaml
@@ -13,7 +13,7 @@ WIDTH = 3
 def acknowledgments(pargs, kwargs, node):
     """Convert acknowledgments to HTML table."""
     util.require((not pargs) and (not kwargs), "Bad 'acknowledgments' shortcode")
-    filename = ivy.site.config.get("acknowledgments", None)
+    filename = ark.site.config.get("acknowledgments", None)
     util.require(filename is not None, "No acnowledgments specified")
 
     with open(filename, "r") as reader:

--- a/lib/mccole/extensions/bib.py
+++ b/lib/mccole/extensions/bib.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-import ivy
+import ark
 import shortcodes
 import util
 from pybtex.database import parse_file
@@ -34,10 +34,10 @@ def bibliography(pargs, kwargs, node):
         f"Bad 'bibliography' shortcode {pargs} and {kwargs}",
     )
 
-    filename = ivy.site.config.get("bibliography", None)
+    filename = ark.site.config.get("bibliography", None)
     util.require(filename is not None, "No bibliography specified")
 
-    stylename = ivy.site.config.get("bibliography_style", None)
+    stylename = ark.site.config.get("bibliography_style", None)
     util.require(stylename is not None, "No bibliography style specified")
 
     bib = _read_bibliography(filename, stylename)
@@ -50,12 +50,12 @@ def bibliography(pargs, kwargs, node):
     return '<dl class="bib-list">\n\n' + "\n\n".join(entries) + "\n\n</dl>"
 
 
-@ivy.events.register(ivy.events.Event.EXIT)
+@ark.events.register(ark.events.Event.EXIT)
 def check_bibliography():
     """Check that bibliogrpahy entries are defined and used."""
-    if (filename := ivy.site.config.get("bibliography", None)) is None:
+    if (filename := ark.site.config.get("bibliography", None)) is None:
         return
-    if (stylename := ivy.site.config.get("bibliography_style", None)) is None:
+    if (stylename := ark.site.config.get("bibliography_style", None)) is None:
         return
     if (used := util.get_config("bibliography")) is None:
         return
@@ -69,7 +69,7 @@ def check_bibliography():
 
 def _read_bibliography(filename, style):
     """Load the bibliography file."""
-    filename = Path(ivy.site.home(), filename)
+    filename = Path(ark.site.home(), filename)
     bib = parse_file(filename)
 
     style = find_plugin("pybtex.style.formatting", style)()

--- a/lib/mccole/extensions/config.py
+++ b/lib/mccole/extensions/config.py
@@ -1,4 +1,4 @@
-import ivy
+import ark
 import shortcodes
 import util
 
@@ -10,7 +10,7 @@ def glossary_ref(pargs, kwargs, node):
     )
     key = pargs[0]
     if key == "email":
-        assert key in ivy.site.config, f"No email address in configuration"
-        email = ivy.site.config["email"]
+        assert key in ark.site.config, f"No email address in configuration"
+        email = ark.site.config["email"]
         return f'<a href="mailto:{email}" class="email">{email}</a>'
     assert False, f"Unknown 'config' key {key}"

--- a/lib/mccole/extensions/copyfiles.py
+++ b/lib/mccole/extensions/copyfiles.py
@@ -4,13 +4,13 @@ from glob import iglob
 from pathlib import Path
 from shutil import copyfile
 
-import ivy
+import ark
 
 
-@ivy.events.register(ivy.events.Event.INIT)
+@ark.events.register(ark.events.Event.INIT)
 def copy_files():
     """Copy files."""
-    patterns = ivy.site.config.get("copy", None)
+    patterns = ark.site.config.get("copy", None)
 
     # Nothing to copy.
     if patterns is None:
@@ -18,8 +18,8 @@ def copy_files():
 
     # Copy everything that matches.
     for pat in patterns:
-        src_dir = ivy.site.src()
-        out_dir = ivy.site.out()
+        src_dir = ark.site.src()
+        out_dir = ark.site.out()
         pat = Path(src_dir, "**", pat)
         for src_file in iglob(str(pat), recursive=True):
             out_file = src_file.replace(src_dir, out_dir)

--- a/lib/mccole/extensions/credits.py
+++ b/lib/mccole/extensions/credits.py
@@ -1,6 +1,6 @@
 """Generate credits."""
 
-import ivy
+import ark
 import shortcodes
 import util
 import yaml
@@ -11,10 +11,10 @@ def bibliography(pargs, kwargs, node):
     """Insert credits."""
     util.require((not pargs) and (not kwargs), "Bad 'credits' shortcode")
 
-    filename = ivy.site.config.get("credits", None)
+    filename = ark.site.config.get("credits", None)
     util.require(filename is not None, "No credits specified")
 
-    lang = ivy.site.config.get("lang", None)
+    lang = ark.site.config.get("lang", None)
     util.require(lang is not None, "No language specified")
 
     with open(filename, "r") as reader:

--- a/lib/mccole/extensions/exclude.py
+++ b/lib/mccole/extensions/exclude.py
@@ -3,17 +3,17 @@
 from fnmatch import fnmatch
 from pathlib import Path
 
-import ivy
+import ark
 from util import read_directives
 
 
-@ivy.filters.register(ivy.filters.Filter.LOAD_NODE_FILE)
+@ark.filters.register(ark.filters.Filter.LOAD_NODE_FILE)
 def keep_file(value, filepath):
     """Only process the right kinds of files."""
     return not _ignore(Path(filepath).parent, filepath)
 
 
-@ivy.filters.register(ivy.filters.Filter.LOAD_NODE_DIR)
+@ark.filters.register(ark.filters.Filter.LOAD_NODE_DIR)
 def keep_dir(value, dirpath):
     """Do not process directories excluded by parent."""
     return not _ignore(Path(dirpath).parent, dirpath)
@@ -22,6 +22,6 @@ def keep_dir(value, dirpath):
 def _ignore(dirpath, filepath):
     """Check for pattern-based exclusion."""
     directives = read_directives(dirpath, "exclude")
-    configured = ivy.site.config.get("exclude", [])
+    configured = ark.site.config.get("exclude", [])
     combined = directives + configured
     return any(fnmatch(filepath.name, pat) for pat in combined)

--- a/lib/mccole/extensions/figures.py
+++ b/lib/mccole/extensions/figures.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from textwrap import dedent
 
-import ivy
+import ark
 import shortcodes
 import util
 
@@ -13,7 +13,7 @@ import util
 class Figure:
     """Keep track of information about a figure."""
 
-    node: ivy.nodes.Node = None
+    node: ark.nodes.Node = None
     fileslug: str = ""
     cls: str = ""
     slug: str = ""
@@ -24,13 +24,13 @@ class Figure:
     width: str = ""
 
 
-@ivy.events.register(ivy.events.Event.INIT)
+@ark.events.register(ark.events.Event.INIT)
 def collect():
     """Collect information from pages."""
     # Gather data.
     major = util.make_major()
     collected = {}
-    ivy.nodes.root().walk(lambda node: _collect(node, major, collected))
+    ark.nodes.root().walk(lambda node: _collect(node, major, collected))
     _cleanup(major, collected)
 
 

--- a/lib/mccole/extensions/glossary.py
+++ b/lib/mccole/extensions/glossary.py
@@ -2,7 +2,7 @@
 
 import re
 
-import ivy
+import ark
 import shortcodes
 import util
 
@@ -11,12 +11,12 @@ INTERNAL_REF = re.compile(r"\]\(#(.+?)\)")
 
 # ----------------------------------------------------------------------
 
-@ivy.events.register(ivy.events.Event.INIT)
+@ark.events.register(ark.events.Event.INIT)
 def collect():
     """Collect information from pages."""
     major = util.make_major()
     collected = {}
-    ivy.nodes.root().walk(lambda node: _collect(node, major, collected))
+    ark.nodes.root().walk(lambda node: _collect(node, major, collected))
     _cleanup(collected)
 
 
@@ -37,10 +37,10 @@ def _parse(pargs, kwargs, data):
 
 def _cleanup(collected):
     """Translate glossary definitions into required form."""
-    filename = ivy.site.config.get("glossary", None)
+    filename = ark.site.config.get("glossary", None)
     util.require(filename is not None, "No glossary specified")
 
-    lang = ivy.site.config.get("lang", None)
+    lang = ark.site.config.get("lang", None)
     util.require(lang is not None, "No language specified")
 
     glossary = util.read_glossary(filename)
@@ -76,10 +76,10 @@ def glossary(pargs, kwargs, node):
         (not pargs) and (not kwargs), f"Bad 'glossary' shortcode {pargs} and {kwargs}"
     )
 
-    filename = ivy.site.config.get("glossary", None)
+    filename = ark.site.config.get("glossary", None)
     util.require(filename is not None, "No glossary specified")
 
-    lang = ivy.site.config.get("lang", None)
+    lang = ark.site.config.get("lang", None)
     util.require(lang is not None, "No language specified")
 
     glossary = util.read_glossary(filename)
@@ -93,13 +93,13 @@ def glossary(pargs, kwargs, node):
     return f'<div class="glossary" markdown="1">\n{entries}\n</div>'
 
 
-@ivy.events.register(ivy.events.Event.EXIT)
+@ark.events.register(ark.events.Event.EXIT)
 def check():
     """Check that glossary entries are defined and used."""
-    filename = ivy.site.config.get("glossary", None)
+    filename = ark.site.config.get("glossary", None)
     util.require(filename is not None, "No glossary specified")
 
-    lang = ivy.site.config.get("lang", None)
+    lang = ark.site.config.get("lang", None)
     util.require(lang is not None, "No language defined for glossary")
 
     glossary = util.read_glossary(filename)

--- a/lib/mccole/extensions/heading.py
+++ b/lib/mccole/extensions/heading.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import sys
 
 import ibis
-import ivy
+import ark
 import shortcodes
 import util
 
@@ -21,16 +21,16 @@ class Heading:
     label: str = ""
 
 
-@ivy.events.register(ivy.events.Event.INIT)
+@ark.events.register(ark.events.Event.INIT)
 def collect():
     """Collect information from pages."""
     # Gather data.
     major = util.make_major()
     collected = {}
-    ivy.nodes.root().walk(lambda node: _collect(node, major, collected))
+    ark.nodes.root().walk(lambda node: _collect(node, major, collected))
     _number(collected, major)
     _flatten(collected)
-    ivy.nodes.root().walk(_modify)
+    ark.nodes.root().walk(_modify)
     _titles()
 
 
@@ -120,11 +120,11 @@ def _titles():
     """Create list of chapter/appendix titles for contents listing."""
     headings = util.get_config("headings")
 
-    chapters = [headings[slug] for slug in ivy.site.config["chapters"]]
+    chapters = [headings[slug] for slug in ark.site.config["chapters"]]
     for (i, entry) in enumerate(chapters):
         entry.label = str(i + 1)
 
-    appendices = [headings[slug] for slug in ivy.site.config["appendices"]]
+    appendices = [headings[slug] for slug in ark.site.config["appendices"]]
     for (i, entry) in enumerate(appendices):
          entry.label = chr(ord("A") + i)
 

--- a/lib/mccole/extensions/includes.py
+++ b/lib/mccole/extensions/includes.py
@@ -39,12 +39,12 @@ To make this work:
 import re
 from pathlib import Path
 
-import ivy
+import ark
 import shortcodes
 import util
 
 
-@ivy.filters.register(ivy.filters.Filter.LOAD_NODE_FILE)
+@ark.filters.register(ark.filters.Filter.LOAD_NODE_FILE)
 def filter_files(value, filepath):
     """Only process HTML and Markdown files."""
     result = filepath.suffix in {".html", ".md"}

--- a/lib/mccole/extensions/index.py
+++ b/lib/mccole/extensions/index.py
@@ -13,17 +13,17 @@ around the glossary shortcode:
 -   `make_index` displays the entire index.
 """
 
-import ivy
+import ark
 import shortcodes
 import util
 
 
-@ivy.events.register(ivy.events.Event.INIT)
+@ark.events.register(ark.events.Event.INIT)
 def collect():
     """Collect information from pages."""
     major = util.make_major()
     collected = util.make_config("index")
-    ivy.nodes.root().walk(lambda node: _collect(node, major, collected))
+    ark.nodes.root().walk(lambda node: _collect(node, major, collected))
 
 
 def _collect(node, major, collected):

--- a/lib/mccole/extensions/links.py
+++ b/lib/mccole/extensions/links.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-import ivy
+import ark
 import shortcodes
 import util
 import yaml
@@ -10,10 +10,10 @@ from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor
 
 
-@ivy.events.register(ivy.events.Event.INIT)
+@ark.events.register(ark.events.Event.INIT)
 def links_append():
     """Add Markdown links table to Markdown files."""
-    if "links" not in ivy.site.config:
+    if "links" not in ark.site.config:
         return
 
     links = _read_links()
@@ -23,15 +23,15 @@ def links_append():
         if node.ext == "md":
             node.text += "\n\n" + links
 
-    ivy.nodes.root().walk(visitor)
+    ark.nodes.root().walk(visitor)
 
 
 @shortcodes.register("links")
 def links_table(pargs, kwargs, node):
     """Create a table of links."""
-    util.require("links" in ivy.site.config, "No links specified")
+    util.require("links" in ark.site.config, "No links specified")
 
-    lang = ivy.site.config.get("lang", None)
+    lang = ark.site.config.get("lang", None)
     util.require(lang is not None, "No language specified")
 
     links = _read_links()
@@ -43,12 +43,12 @@ def links_table(pargs, kwargs, node):
     return f"<ul>\n{links}\n</ul>"
 
 
-@ivy.events.register(ivy.events.Event.EXIT)
+@ark.events.register(ark.events.Event.EXIT)
 def check():
     """Check link usage."""
     used = set()
     ext = LinkCollectorExtension(used)
-    ivy.nodes.root().walk(
+    ark.nodes.root().walk(
         lambda node: util.markdownify(node.text, ext=ext, strip=False)
     )
 
@@ -91,6 +91,6 @@ def _link_key(item, lang):
 
 def _read_links():
     """Read links file."""
-    filepath = Path(ivy.site.home(), ivy.site.config["links"])
+    filepath = Path(ark.site.home(), ark.site.config["links"])
     with open(filepath, "r") as reader:
         return yaml.safe_load(reader)

--- a/lib/mccole/extensions/reviewers.py
+++ b/lib/mccole/extensions/reviewers.py
@@ -1,6 +1,6 @@
 """Build a list of reviewers."""
 
-import ivy
+import ark
 import shortcodes
 import util
 import yaml
@@ -15,8 +15,8 @@ def reviewers_list(pargs, kwargs, node):
             return f'<li><a href="{entry["url"]}">{entry["name"]}</a></li>'
         return f'<li>{entry["name"]}</li>'
 
-    util.require("reviewers" in ivy.site.config, "No reviewers specified")
-    with open(ivy.site.config["reviewers"], "r") as reader:
+    util.require("reviewers" in ark.site.config, "No reviewers specified")
+    with open(ark.site.config["reviewers"], "r") as reader:
         reviewers = yaml.safe_load(reader)
     reviewers = [_format(r) for r in reviewers]
     return "<ul>\n" + "\n".join(reviewers) + "\n</ul>"

--- a/lib/mccole/extensions/root.py
+++ b/lib/mccole/extensions/root.py
@@ -3,7 +3,7 @@
 import re
 from pathlib import Path
 
-import ivy
+import ark
 import shortcodes
 import util
 
@@ -18,7 +18,7 @@ def root(pargs, kwargs, node):
     )
 
     filename = pargs[0]
-    fullpath = Path(ivy.site.home(), filename)
+    fullpath = Path(ark.site.home(), filename)
     util.require(fullpath.exists(), f"No file {filename} in root directory")
     with open(fullpath, "r") as reader:
         content = reader.read()

--- a/lib/mccole/extensions/syllabus.py
+++ b/lib/mccole/extensions/syllabus.py
@@ -1,13 +1,13 @@
-import ivy
+import ark
 import shortcodes
 import util
 
-@ivy.events.register(ivy.events.Event.INIT)
+@ark.events.register(ark.events.Event.INIT)
 def collect():
     """Collect information from pages."""
     major = util.make_major()
     collected = {}
-    ivy.nodes.root().walk(lambda node: _collect(node, major, collected))
+    ark.nodes.root().walk(lambda node: _collect(node, major, collected))
     _cleanup(collected)
 
 
@@ -21,7 +21,7 @@ def _cleanup(collected):
     """Clean up collected data."""
     syllabi = [
         (slug, collected[slug][0], collected[slug][1])
-        for slug in ivy.site.config["chapters"]
+        for slug in ark.site.config["chapters"]
         if slug in collected
     ]
     util.make_config("syllabus", syllabi)

--- a/lib/mccole/extensions/tables.py
+++ b/lib/mccole/extensions/tables.py
@@ -44,7 +44,7 @@ so tables are represented as:
 
 from dataclasses import dataclass
 
-import ivy
+import ark
 import shortcodes
 import util
 
@@ -60,12 +60,12 @@ class Table:
     number: tuple = ()
 
 
-@ivy.events.register(ivy.events.Event.INIT)
+@ark.events.register(ark.events.Event.INIT)
 def collect():
     """Collect information from pages."""
     major = util.make_major()
     collected = {}
-    ivy.nodes.root().walk(lambda node: _collect(node, major, collected))
+    ark.nodes.root().walk(lambda node: _collect(node, major, collected))
     _cleanup(major, collected)
 
 
@@ -124,7 +124,7 @@ def table_ref(pargs, kwargs, node):
     return f'<a {cls} href="@root/{table.fileslug}/#{slug}">{label}</a>'
 
 
-@ivy.filters.register(ivy.filters.Filter.NODE_HTML)
+@ark.filters.register(ark.filters.Filter.NODE_HTML)
 def table_caption(text, node):
     """Get the caption in the right place."""
 

--- a/lib/mccole/extensions/util.py
+++ b/lib/mccole/extensions/util.py
@@ -5,7 +5,7 @@ import re
 import sys
 from pathlib import Path
 
-import ivy
+import ark
 import markdown
 import yaml
 
@@ -14,7 +14,7 @@ DIRECTIVES_FILE = ".mccole"
 
 # Configuration sections and their default values.
 # These are added to the config dynamically under the `mccole` key,
-# i.e., `"figures"` becomes `ivy.site.config["mccole"]["figures"]`.
+# i.e., `"figures"` becomes `ark.site.config["mccole"]["figures"]`.
 CONFIGURATIONS = {
     "bibliography": set(),  # citations
     "definitions": [],  # glossary definitions
@@ -77,7 +77,7 @@ def get_config(part):
     in the processing cycle.
     """
     require(part in CONFIGURATIONS, f"Unknown configuration section '{part}'")
-    mccole = ivy.site.config.setdefault("mccole", {})
+    mccole = ark.site.config.setdefault("mccole", {})
     return mccole.get(part, None)
 
 
@@ -89,7 +89,7 @@ def make_config(part, filler=None):
     """
     require(part in CONFIGURATIONS, f"Unknown configuration section '{part}'")
     filler = filler if (filler is not None) else CONFIGURATIONS[part]
-    return ivy.site.config.setdefault("mccole", {}).setdefault(part, filler)
+    return ark.site.config.setdefault("mccole", {}).setdefault(part, filler)
 
 
 def make_copy_paths(node, filename, original=None, replacement=None):
@@ -103,7 +103,7 @@ def make_copy_paths(node, filename, original=None, replacement=None):
 
 def make_label(kind, number):
     """Create numbered labels for figures, tables, and document parts."""
-    translations = TRANSLATIONS[ivy.site.config["lang"]]
+    translations = TRANSLATIONS[ark.site.config["lang"]]
     if kind == "figure":
         name = translations["figure"]
     elif kind == "part":
@@ -128,10 +128,10 @@ def make_major():
     This function relies on the configuration containing `"chapters"`
     and `"appendices"`, which must be lists of slugs.
     """
-    chapters = {slug: i + 1 for (i, slug) in enumerate(ivy.site.config["chapters"])}
+    chapters = {slug: i + 1 for (i, slug) in enumerate(ark.site.config["chapters"])}
     appendices = {
         slug: chr(ord("A") + i)
-        for (i, slug) in enumerate(ivy.site.config["appendices"])
+        for (i, slug) in enumerate(ark.site.config["appendices"])
     }
     return chapters | appendices
 
@@ -149,7 +149,7 @@ def markdownify(text, ext=None, strip=True):
 
 def mccole():
     """Get configuration section, creating if necessary."""
-    return ivy.site.config.setdefault("mccole", {})
+    return ark.site.config.setdefault("mccole", {})
 
 
 def read_directives(dirname, section):
@@ -164,10 +164,10 @@ def read_directives(dirname, section):
 
 def read_glossary(filename):
     """Load the glossary definitions."""
-    filename = Path(ivy.site.home(), filename)
+    filename = Path(ark.site.home(), filename)
     with open(filename, "r") as reader:
         result = yaml.safe_load(reader) or []
-        lang = ivy.site.config.get("lang", None)
+        lang = ark.site.config.get("lang", None)
         if lang is not None:
             for entry in result:
                 assert lang in entry, f"Bad glossary entry {entry}"
@@ -183,7 +183,7 @@ def require(cond, msg):
 
 def warn(title, items):
     """Warn about missing or unused items."""
-    if not ivy.site.config.get("warnings", False):
+    if not ark.site.config.get("warnings", False):
         return
     if not items:
         return

--- a/lib/mccole/generic.mk
+++ b/lib/mccole/generic.mk
@@ -35,12 +35,12 @@ commands:
 ## build: rebuild site without running server
 build: ./docs/index.html
 ./docs/index.html: ${SRC} ${INFO} ${IVY} config.py
-	ivy build && touch $@
+	ark build && touch $@
 
 ## serve: build site and run server
 .PHONY: serve
 serve:
-	ivy watch --port ${PORT}
+	ark watch --port ${PORT}
 
 ## single: create single-page HTML
 single: docs/all.html
@@ -186,7 +186,7 @@ publisher:
 .PHONY: export
 export:
 	rm -rf ${MCCOLE}
-	MCCOLE=${MCCOLE} ivy build
+	MCCOLE=${MCCOLE} ark build
 	@zip -q -r ${MCCOLE}/${ABBREV}-examples.zip docs \
 	-i '*.ht' '*.json' '*.out' '*.py' '*.sh' '*.txt' '*.yml' \
 	-x '*.html'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4>=4.11
-ivy>=6.4
+ark>=7.1
 pybtex>=0.24
 pymdown-extensions>=9.5


### PR DESCRIPTION
Hi @gvwilson, long time no see.
According to [this commit](https://github.com/dmulholl/ark/commit/8ce67f2b9042046c8fb6173a8748dcb661801271) the `ivy` project has been renamed to `ark`. I noticed it when trying to install `ivy` from `pip`:
```
pip install ivy
ERROR: Could not find a version that satisfies the requirement ivy (from versions: none)
ERROR: No matching distribution found for ivy
```
I haven't tested it massively, but at least the `make serve` command works again. The pdf is not generated, though. I think that it is due to another - not `ivy` related - problem.