### PR TITLE
Fix: malformed yaml file was unparseable.

### DIFF
--- a/info/glossary.yml
+++ b/info/glossary.yml
@@ -3781,7 +3781,7 @@
     term: generador de sitio estático
     def: >
       Una herramienta de software que crea páginas HTML a partir de plantillas y
-  contenido.
+      contenido.
 
 - key: stream
   en:


### PR DESCRIPTION
YAML glossary was invalid due to a whitespace error.